### PR TITLE
fix: pyyaml <6.0 not supporting python 3.12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,8 @@ runs:
       name: Install PyYAML library
       shell: bash
       run: |
-        pip install PyYAML==6.0
+        pip install --upgrade pip
+        pip install PyYAML==6.0.1
     - id: extract-entity-info
       name: Extract entity information from catalog file
       shell: python


### PR DESCRIPTION
current techdocs github actions [fail to run](https://github.com/TierMobility/geo-services/actions/runs/6768978247/job/18396048466) when installing pyyaml <6.0.1 on python 3.12. [#756](https://github.com/yaml/pyyaml/issues/756#issuecomment-1751971477) suggests that installing pyyaml >6.0.0 would resolve the issue.